### PR TITLE
Add namespace to metrics

### DIFF
--- a/docker-proxy-webhook/api/v1/docker_proxy_mutating_webhook.go
+++ b/docker-proxy-webhook/api/v1/docker_proxy_mutating_webhook.go
@@ -48,28 +48,28 @@ var (
 			Name: "docker_proxy_mutating_webhook_result_total",
 			Help: "Number of webhook invocations",
 		},
-		[]string{"mutated", "namespace"},
+		[]string{"mutated", "pod_namespace"},
 	)
 	webhookFailureCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "docker_proxy_mutating_webhook_failures_total",
 			Help: "Number of webhook failures'",
 		},
-		[]string{"failure_reason", "namespace"},
+		[]string{"failure_reason", "pod_namespace"},
 	)
 	containerRewriteCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "docker_proxy_mutating_webhook_container_rewrites_total",
 			Help: "Number of container image values rewritten",
 		},
-		[]string{"domain", "namespace"},
+		[]string{"domain", "pod_namespace"},
 	)
 	unknownDomainCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "docker_proxy_mutating_webhook_unknown_domain_total",
 			Help: "Number of unmapped domains",
 		},
-		[]string{"domain", "namespace"})
+		[]string{"domain", "pod_namespace"})
 )
 
 // log is for logging in this package.

--- a/docker-proxy-webhook/api/v1/docker_proxy_mutating_webhook.go
+++ b/docker-proxy-webhook/api/v1/docker_proxy_mutating_webhook.go
@@ -216,9 +216,9 @@ func RewriteImage(image string, namespace string, config DockerConfig) (string, 
 		log.V(2).Info("Found unmapped domain", "domain", domain)
 		unknownDomainCount.WithLabelValues(domain, namespace).Inc()
 		newImage = domain
+	} else {
+		containerRewriteCounter.WithLabelValues(reference.Domain(named), namespace).Inc()
 	}
-
-	containerRewriteCounter.WithLabelValues(reference.Domain(named), namespace).Inc()
 
 	newImage += "/" + reference.Path(named)
 

--- a/docker-proxy-webhook/api/v1/docker_proxy_mutating_webhook_test.go
+++ b/docker-proxy-webhook/api/v1/docker_proxy_mutating_webhook_test.go
@@ -69,10 +69,14 @@ func TestRewriteImage(t *testing.T) {
 			Image:    "unmapped-domain.com/registry/repo",
 			Expected: "unmapped-domain.com/registry/repo",
 		},
+		{
+			Image:    "org-name-docker-io.jfrog.io/already-mapped-domain/test",
+			Expected: "org-name-docker-io.jfrog.io/already-mapped-domain/test",
+		},
 	}
 
 	for _, tcase := range tcases {
-		img, err := RewriteImage(tcase.Image, config)
+		img, err := RewriteImage(tcase.Image, "my_namespace", config)
 		if err != nil {
 			t.Errorf("Expected: %v. Got error: %v", tcase.Expected, err)
 		} else if img != tcase.Expected {
@@ -81,7 +85,7 @@ func TestRewriteImage(t *testing.T) {
 	}
 
 	// another test case for err != nil
-	img, err := RewriteImage("INVALID-UPPERCASE-REPO", config)
+	img, err := RewriteImage("INVALID-UPPERCASE-REPO", "my_namespace", config)
 	if err == nil {
 		t.Errorf("Expected error. Got: %v", img)
 	}


### PR DESCRIPTION
- Add `namespace` to metrics
- Fix metrics where `Inc()` was missing
- Return early if the incoming domain matches a domain in the rewrite map
   to avoid incrementing the 'unknown domain' counter
