### PR TITLE
Log updates

### DIFF
--- a/docker-proxy-webhook/api/v1/docker_proxy_mutating_webhook.go
+++ b/docker-proxy-webhook/api/v1/docker_proxy_mutating_webhook.go
@@ -219,7 +219,7 @@ func RewriteImage(image string, namespace string, config DockerConfig) (string, 
 	}
 
 	if newImage == "" {
-		log.V(2).Info("Found unmapped domain", "domain", domain)
+		log.V(1).Info("Found unmapped domain", "domain", domain)
 		unknownDomainCounter.WithLabelValues(domain, namespace).Inc()
 		newImage = domain
 	} else {

--- a/docker-proxy-webhook/main.go
+++ b/docker-proxy-webhook/main.go
@@ -57,7 +57,9 @@ func main() {
 
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	if _, exists := os.LookupEnv("KUBERNETES_SERVICE_HOST"); !exists {
+		ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,


### PR DESCRIPTION
- Try logging 'unknown domain' error at level 1, since level 2 log
  messages appear missing.
- If running inside k8s do not use the 'dev mode' logger
